### PR TITLE
When no external scores provided, make `external_options` empty

### DIFF
--- a/run.R
+++ b/run.R
@@ -111,17 +111,21 @@ ensemble_options <- setNames(
 
 external_options <- tar_read(external_names)
 EXTERNAL_PREFIX <- "[external] "
-external_options <- setNames(
-  # File names
-  # Get names of all branches of `external_scores` target by index. The way these
-  # were specified, `external_names` provides the order of the branches.
-  tar_branch_names(external_scores, seq_along(external_options)),
-  # Display names
-  paste0(
-    EXTERNAL_PREFIX,
-    gsub(" forecaster", "", gsub("_", " ", external_options, fixed = TRUE), fixed = TRUE)
+if (!is.null(external_options) && length(external_options) > 0) {
+  external_options <- setNames(
+    # File names
+    # Get names of all branches of `external_scores` target by index. The way these
+    # were specified, `external_names` provides the order of the branches.
+    tar_branch_names(external_scores, seq_along(external_options)),
+    # Display names
+    paste0(
+      EXTERNAL_PREFIX,
+      gsub(" forecaster", "", gsub("_", " ", external_options, fixed = TRUE), fixed = TRUE)
+    )
   )
-)
+} else {
+  external_options <- character(0)
+}
 
 forecaster_options <- c(ensemble_options, forecaster_options, external_options)
 


### PR DESCRIPTION
Due to behavior of `gsub` and `paste0`, `setNames` was erroring when trying to combine a length-0 and a length-1 vector when no external scores path is provided.