### PR TITLE
refactor: don't hide caching in package .onLoad

### DIFF
--- a/R/epieval-package.R
+++ b/R/epieval-package.R
@@ -4,12 +4,4 @@
 #' @importFrom purrr transpose map map2_vec
 #' @keywords internal
 "_PACKAGE"
-globalVariables(c("ahead", "id", "parent_id", "all_of", "last_col", "time_value", "geo_value", "target_end_date", "forecast_date", "quantile", ".pred_distn", "quantiles", "quantile_levels", "signal", ".dstn", "values", ".", "forecasters","forecaster", "trainer", "forecast_date", ".pred", "n_distinct", "target_date", "value"))
-.onLoad <- function(libname, pkgname) {
-  epidatr::set_cache(
-    cache_dir = ".exploration_cache",
-    days = 14,
-    max_size = 4,
-    confirm = FALSE
-  )
-}
+globalVariables(c("ahead", "id", "parent_id", "all_of", "last_col", "time_value", "geo_value", "target_end_date", "forecast_date", "quantile", ".pred_distn", "quantiles", "quantile_levels", "signal", ".dstn", "values", ".", "forecasters", "forecaster", "trainer", "forecast_date", ".pred", "n_distinct", "target_date", "value"))

--- a/covid_hosp_explore.R
+++ b/covid_hosp_explore.R
@@ -12,6 +12,7 @@ suppressPackageStartupMessages({
   library(tibble)
   library(tidyr)
   library(rlang)
+  library(epidatr)
 })
 
 # The external scores processing causes the pipeline to exit with an error,
@@ -167,7 +168,7 @@ if (LOAD_EXTERNAL_SCORES) {
       command = {
         readRDS(external_scores_path) %>%
           group_by(forecaster) %>%
-          targets::tar_group()
+          tar_group()
       },
       iteration = "group",
       garbage_collection = TRUE

--- a/covid_hosp_explore/data_targets.R
+++ b/covid_hosp_explore/data_targets.R
@@ -2,7 +2,7 @@ data_targets <- local({
   geo_type <- "state"
   time_type <- "day"
   geo_values <- "*"
-  time_values <- epidatr::epirange(from = "2020-01-01", to = "2024-01-01")
+  time_values <- epirange(from = "2020-01-01", to = "2024-01-01")
   fetch_args <- fetch_args_list(return_empty = TRUE, timeout_seconds = 200)
   issues <- "*"
 
@@ -10,7 +10,7 @@ data_targets <- local({
     tar_target(
       name = hhs_latest_data,
       command = {
-        epidatr::pub_covidcast(
+        pub_covidcast(
           source = "hhs",
           signals = "confirmed_admissions_covid_1d",
           geo_type = geo_type,
@@ -24,7 +24,7 @@ data_targets <- local({
     tar_target(
       name = chng_latest_data,
       command = {
-        epidatr::pub_covidcast(
+        pub_covidcast(
           source = "chng",
           signals = "smoothed_adj_outpatient_covid",
           geo_type = geo_type,
@@ -62,7 +62,7 @@ data_targets <- local({
     tar_target(
       name = hhs_archive_data_2022,
       command = {
-        epidatr::pub_covidcast(
+        pub_covidcast(
           source = "hhs",
           signals = "confirmed_admissions_covid_1d",
           geo_type = geo_type,
@@ -77,7 +77,7 @@ data_targets <- local({
     tar_target(
       name = chng_archive_data_2022,
       command = {
-        epidatr::pub_covidcast(
+        pub_covidcast(
           source = "chng",
           signals = "smoothed_adj_outpatient_covid",
           geo_type = geo_type,

--- a/flu_hosp_explore.R
+++ b/flu_hosp_explore.R
@@ -31,7 +31,7 @@ tar_option_set(
   imports = c("epieval", "parsnip"),
   format = "qs", # Optionally set the default storage format. qs is fast.
   controller = crew::crew_controller_local(workers = parallel::detectCores() - 5),
-  )
+)
 # Run the R scripts in the R/ folder with your custom functions:
 # tar_source()
 linreg <- parsnip::linear_reg()


### PR DESCRIPTION
Was surprising to me that caching was being set in epieval `.onLoad`. I think caching should be opt in instead (and set in env vars for consistency across targets projects).