### PR TITLE
feat: lineplot, parameter tables

### DIFF
--- a/app.R
+++ b/app.R
@@ -125,10 +125,22 @@ shinyApp(
             multiple = TRUE,
             selected = c("as", "gu", "mp", "vi")
           ),
+          selectInput("excluded_aheads",
+            "Exclude aheads:",
+            choices = 1:28,
+            multiple = TRUE
+          )
         ),
         mainPanel(
-          plotlyOutput("main_plot", height = "90em"),
-          width=8
+          verticalLayout(
+            plotlyOutput("main_plot", height = "90em"),
+            h2("forecaster name -> parameters"),
+            #textOutput("forecaster_param_title"),
+            dataTableOutput("forecaster_table"),
+            h2("ensemble name -> parameters"),
+            dataTableOutput("ensemble_table")
+          ),
+          width = 8
         )
       )
     )
@@ -137,24 +149,27 @@ shinyApp(
     filtered_scorecards_reactive <- reactive({
       agg_forecasters <- unique(c(input$selected_forecasters, input$baseline))
       if (length(agg_forecasters) == 0 ||
-          all(agg_forecasters == "" | is.null(agg_forecasters) | is.na(agg_forecasters))
+        all(agg_forecasters == "" | is.null(agg_forecasters) | is.na(agg_forecasters))
       ) {
         return(data.frame())
       }
 
       processed_evaluations_internal <- lapply(agg_forecasters, function(forecaster) {
-          load_forecast_data(forecaster) %>>%
+        load_forecast_data(forecaster) %>>%
           filter(
             .data$forecast_date %>>% between(.env$input$selected_forecast_date_range[[1L]], .env$input$selected_forecast_date_range[[2L]]),
             .data$target_end_date %>>% between(.env$input$selected_target_end_date_range[[1L]], .env$input$selected_target_end_date_range[[2L]]),
-            !.data$geo_value %in% c(.env$input$excluded_geo_values, "us")
+            !.data$geo_value %in% c(.env$input$excluded_geo_values, "us"),
+            !.data$ahead %in% .env$input$excluded_aheads
           )
-        }) %>%
+      }) %>%
         bind_rows()
     })
     output$main_plot <- renderPlotly({
       input_df <- filtered_scorecards_reactive()
-      if (nrow(input_df) == 0) { return() }
+      if (nrow(input_df) == 0) {
+        return()
+      }
 
       # Normalize by baseline scores. This is not relevant for coverage, which is compared
       # to the nominal confidence level.
@@ -184,7 +199,7 @@ shinyApp(
 
       x_tick_angle <- list(tickangle = -30)
       facet_x_tick_angles <- setNames(rep(list(x_tick_angle), 10), paste0("xaxis", 1:10))
-      scale_type <- ifelse(input$facets_share_scale, "fixed", "free_y" )
+      scale_type <- ifelse(input$facets_share_scale, "fixed", "free_y")
 
       input_df %>>%
         # Aggregate scores over all geos
@@ -208,13 +223,11 @@ shinyApp(
           ),
           na.rm = TRUE
         )) %>>%
-        # Use scatterplot or lines depending on the x var. Also, if the range
+        # Use scatterplot or lines depending on the x var. ~~Also, if the range
         # of obs by forecaster is too wide, plot using points instead of
-        # lines.
+        # lines.~~ too wide a range of observations is better than too many thick points
         {
-          if (input$x_var %in% c(input$facet_vars, "geo_value", "forecaster", "ahead") || range(plot.df[["n"]]) %>>% {
-            .[[2L]] > 1.2 * .[[1L]]
-          }) {
+          if (input$x_var %in% c(input$facet_vars, "geo_value", "forecaster", "ahead")) {
             . + geom_point(aes(size = n)) + expand_limits(size = 0)
           } else {
             . + geom_line()
@@ -228,9 +241,36 @@ shinyApp(
         } else {
           facet_grid(as.formula(paste0(input$facet_vars[[1L]], " ~ ", paste(collapse = " + ", input$facet_vars[-1L]))), scales = scale_type)
         }) %>>%
-        ggplotly() %>>%
-        {inject(layout(., hovermode = "x unified", legend = list(orientation = "h", title = list(text = "forecaster")), xaxis = x_tick_angle, !!!facet_x_tick_angles))}
-
+        ggplotly() %>>% {
+          inject(layout(., hovermode = "x unified", legend = list(orientation = "h", title = list(text = "forecaster")), xaxis = x_tick_angle, !!!facet_x_tick_angles))
+        }
     })
+    ## output$forecaster_param_title <- renderText("forecast name -> parameters")
+
+    output$forecaster_table <- renderDataTable(
+      tar_read(forecaster_params_grid) %>%
+        select(-id) %>%
+        mutate(across(where(is.list), map, `%||%`, c(0, 7, 14))) %>%
+        mutate(lags = paste(lags, sep = ",")) %>%
+        group_by(parent_id) %>%
+        mutate(ahead = toString(unique(ahead))) %>%
+        ungroup() %>%
+        distinct(parent_id, .keep_all = TRUE) %>%
+        rename(name = parent_id) %>%
+        select(name, everything())
+    )
+    output$ensemble_table <- renderDataTable(
+      tar_read(ensemble_forecasters) %>%
+        select(-id) %>%
+        group_by(parent_id) %>%
+        mutate(ahead = toString(unique(ahead))) %>%
+        ungroup() %>%
+        distinct(parent_id, .keep_all = TRUE) %>%
+        rename(name = parent_id) %>%
+        mutate(ensemble_params = paste(ensemble_params, sep = ",")) %>%
+        mutate(forecaster_ids = paste(forecaster_ids, sep = ",")) %>%
+        select(name, everything()) %>%
+        select(-forecasters)
+    )
   }
 )

--- a/app.R
+++ b/app.R
@@ -223,9 +223,7 @@ shinyApp(
           ),
           na.rm = TRUE
         )) %>>%
-        # Use scatterplot or lines depending on the x var. ~~Also, if the range
-        # of obs by forecaster is too wide, plot using points instead of
-        # lines.~~ too wide a range of observations is better than too many thick points
+        # Use scatterplot or lines depending on the x var.
         {
           if (input$x_var %in% c(input$facet_vars, "geo_value", "forecaster", "ahead")) {
             . + geom_point(aes(size = n)) + expand_limits(size = 0)
@@ -245,8 +243,6 @@ shinyApp(
           inject(layout(., hovermode = "x unified", legend = list(orientation = "h", title = list(text = "forecaster")), xaxis = x_tick_angle, !!!facet_x_tick_angles))
         }
     })
-    ## output$forecaster_param_title <- renderText("forecast name -> parameters")
-
     output$forecaster_table <- renderDataTable(
       tar_read(forecaster_params_grid) %>%
         select(-id) %>%


### PR DESCRIPTION
This is an update to the shiny plots that does a couple of things:
1. keep lineplots as lineplots, even if the range is too large. This was causing the plots to be fuzzy because of the size of the points
2. exclude aheads as an option
3. 2 tables of the parameters, one for forecasters, one for ensembles
Here is what the result looks like
![image](https://github.com/cmu-delphi/exploration-tooling/assets/7095649/6bf6f728-f867-4819-b6e8-caf060f6f152)
![image](https://github.com/cmu-delphi/exploration-tooling/assets/7095649/3943939a-c6af-4ddc-9e05-de2c76df6717)
And the [bookmark](http://127.0.0.1:3838/?_inputs_&selected_forecasters=%5B%22ensemble_score_wondrous.consolidative%22%2C%22score_unexpected.criminological%22%2C%22score_threadbare.substantial%22%2C%22external_scores_61fe3404%22%5D&baseline=%22ensemble_score_advertent.freemasonic%22&x_var=%22forecast_date%22&facet_vars=%22ahead%22&excluded_geo_values=%5B%22as%22%2C%22gu%22%2C%22vi%22%2C%22mp%22%5D&excluded_aheads=%5B%228%22%2C%229%22%2C%2210%22%2C%2211%22%2C%2212%22%2C%2213%22%2C%2214%22%2C%2215%22%2C%2216%22%2C%2217%22%2C%2218%22%2C%2219%22%2C%2220%22%2C%2221%22%2C%2222%22%2C%2223%22%2C%2224%22%2C%2225%22%2C%2226%22%2C%2227%22%2C%2228%22%5D&selected_forecast_date_range=%5B%222020-01-01%22%2C%222023-11-30%22%5D&selected_target_end_date_range=%5B%222020-01-01%22%2C%222023-11-30%22%5D&selected_metric=%22wis%22&scale_by_baseline=true&facets_share_scale=true&.clientValue-default-plotlyCrosstalkOpts=%7B%22on%22%3A%22plotly_click%22%2C%22persistent%22%3Afalse%2C%22dynamic%22%3Afalse%2C%22selectize%22%3Afalse%2C%22opacityDim%22%3A0.2%2C%22selected%22%3A%7B%22opacity%22%3A1%7D%2C%22debounce%22%3A0%2C%22color%22%3A%5B%5D%7D&plotly_afterplot-A=%22%5C%22main_plot%5C%22%22&plotly_relayout-A=%22%7B%5C%22width%5C%22%3A1250%2C%5C%22height%5C%22%3A1260%7D%22&plotly_hover-A=null) to reproduce this exact plot.