### PR TITLE
new external scores, migrate file into project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,12 @@ sync:
 download:
 	Rscript scripts/sync.R download
 
+pull: download
+
 upload:
 	Rscript scripts/sync.R upload
+
+push: upload
 
 dashboard:
 	Rscript scripts/dashboard.R

--- a/R/manage_S3.R
+++ b/R/manage_S3.R
@@ -51,7 +51,7 @@ manage_S3_forecast_cache <- function(rel_cache_dir = NULL,
   # sync external score file if it exists
   if ((is.null(external_scores_path)) && (external_scores_path != "") && external_scores_path != " ") {
     s3b <- get_bucket(bucket_name, prefix = prefix, max = 1)
-    aws.s3::save_object(paste0(prefix, "/", external_scores_path), s3b)
+    aws.s3::save_object(paste0(project_prefix, "/", external_scores_path), s3b)
   }
   return(TRUE)
 }

--- a/R/targets_utils.R
+++ b/R/targets_utils.R
@@ -266,12 +266,13 @@ make_ensemble_targets_and_scores <- function() {
 #' @export
 make_external_names_and_scores <- function() {
   external_scores_path <- Sys.getenv("EXTERNAL_SCORES_PATH", "")
+  project_path <- Sys.getenv("TAR_PROJECT", "")
   if (external_scores_path != "") {
     external_names_and_scores <- list(
       tar_target(
         name = external_scores_df,
         command = {
-          qs::qread(external_scores_path) %>%
+          qs::qread(paste0(project_path, "/", external_scores_path)) %>%
             group_by(forecaster) %>%
             targets::tar_group()
         },

--- a/README.md
+++ b/README.md
@@ -22,13 +22,20 @@ EXTERNAL_SCORES_PATH=legacy-exploration-scorecards.qs
 AWS_S3_PREFIX=exploration
 
 # Pull from the bucket
-make sync
+make download
+# or
+make pull
 
 # Run only the dashboard, to display results run on other machines
 make dashboard
 
 # Run the pipeline wrapper run.R.
 make run
+
+# upload/push to the bucket even if the results are incomplete
+make upload
+# or
+make push
 
 ```
 

--- a/scripts/covid_hosp_explore.R
+++ b/scripts/covid_hosp_explore.R
@@ -187,6 +187,7 @@ ensembles_and_scores_by_ahead <- tar_map(
 ensembles_and_scores <- make_ensemble_targets_and_scores()
 # other sources
 external_scores_path <- Sys.getenv("EXTERNAL_SCORES_PATH", "")
+project_path <- Sys.getenv("TAR_PROJECT", "")
 external_names_and_scores <- make_external_names_and_scores()
 
 list(

--- a/scripts/dashboard.R
+++ b/scripts/dashboard.R
@@ -1,5 +1,4 @@
 tar_project <- Sys.getenv("TAR_PROJECT", "covid_hosp_explore")
-external_scores_path <- Sys.getenv("EXTERNAL_SCORES_PATH", "")
 debug_mode <- as.logical(Sys.getenv("DEBUG_MODE", TRUE))
 use_shiny <- as.logical(Sys.getenv("USE_SHINY", FALSE))
 use_aws_s3_only <- as.logical(Sys.getenv("USE_AWS_S3_ONLY", FALSE))

--- a/scripts/one_offs/adding_external_covid_scores.R
+++ b/scripts/one_offs/adding_external_covid_scores.R
@@ -1,0 +1,33 @@
+# this is adding the data downloaded from the forecast eval dashboard, as stored here:
+# https://forecast-eval.s3.us-east-2.amazonaws.com/score_cards_state_hospitalizations.rds
+
+data_to_add <- read_rds("scripts/one_offs/score_cards_state_hospitalizations.rds")
+names(data_to_add)
+data_to_add %>% glimpse()
+data_to_add$forecaster %>% unique()
+n_geos <- data_to_add$geo_value %>%
+  unique() %>%
+  length()
+more_than_one_year_forecasters <- data_to_add %>%
+  group_by(forecaster) %>%
+  filter(target_end_date > as.Date("2021-01-01")) %>%
+  summarize(enough = length(wis) / n_geos) %>%
+  filter(enough > 365) %>%
+  pull(forecaster)
+best_15_forecasters <- data_to_add %>%
+  filter(forecaster %in% more_than_one_year_forecasters) %>%
+  group_by(forecaster) %>%
+  summarize(net_wis = sum(wis, na.rm = TRUE) / length(!is.na(wis))) %>%
+  arrange(net_wis) %>%
+  `[`(1:15, ) %>%
+  pull(forecaster)
+best_15_forecasters
+internal_scores <- qs::qread("covid_hosp_explore/legacy-exploration-scorecards.qs")
+new_data <- internal_scores %>% add_row(data_to_add %>% filter(forecaster %in% best_15_forecasters) %>% select(-c("cov_10", "cov_20", "cov_30", "cov_40", "cov_50", "cov_60", "cov_70", "cov_90", "cov_95", "cov_98", "value_20", "value_50", "value_80", "sharpness", "overprediction", "underprediction")))
+new_data$forecaster %>% unique()
+new_data
+qs::qsave(new_data, "covid_hosp_explore/legacy-exploration-scorecards.qs")
+setdiff(names(data_to_add), names(internal_scores))
+
+external_scores <- targets::tar_read("external_scores")
+external_scores

--- a/scripts/one_offs/step-through-smoothed-scaled.R
+++ b/scripts/one_offs/step-through-smoothed-scaled.R
@@ -1,0 +1,157 @@
+library(dplyr)
+library(tidyr)
+library(parallel)
+library(ggplot2)
+library(epidatr)
+library(epiprocess)
+devtools::load_all(export_all = FALSE)
+
+forecast_as_of <- as.Date("2021-11-29")
+
+data_start_date <- as.Date("2020-08-01")
+target_geo_values <- c(tolower(state.abb), "dc", "pr", "vi") # TODO consider national-level
+aheads <- c(0:28)
+## aheads <- c(0L, 7L, 14L, 21L, 28L)
+
+cce <- covidcast_epidata()
+
+hhs_snapshot <-
+  cce$signals$`hhs:confirmed_admissions_covid_1d`$call(
+    "state", target_geo_values,
+    epirange(data_start_date, 34560101),
+    as_of = as.character(forecast_as_of)
+  )
+
+hhs_snapshot_edf <- hhs_snapshot %>%
+  pivot_wider(
+    id_cols = c("geo_value", "time_value"),
+    names_from = c("source", "signal"),
+    values_from = "value"
+  ) %>%
+  as_epi_df(as_of = forecast_as_of)
+
+# get the real data
+hhs_up_to_date <-
+  cce$signals$`hhs:confirmed_admissions_covid_1d`$call(
+    "state", target_geo_values,
+    epirange(data_start_date, forecast_as_of + max(aheads)),
+  )
+
+hhs_up_to_date %<>%
+  pivot_wider(
+    id_cols = c("geo_value", "time_value"),
+    names_from = c("source", "signal"),
+    values_from = "value"
+  ) %>%
+  as_epi_df() %>%
+  filter((geo_value == "az"), (time_value %in% (forecast_as_of + aheads)))
+## debugonce(quantreg::rq.fit)
+
+## smoothed_scaled(
+##   hhs_snapshot_edf,
+##   outcome = "hhs_confirmed_admissions_covid_1d",
+##   trainer = epipredict::quantile_reg(),
+##   ahead = 0L,
+##   lags = list(
+##     # smoothed
+##     7L * (0:4),
+##     # sd
+##     0L
+##   ),
+##   pop_scaling = TRUE
+## )
+
+system.time({
+  fcst <-
+    aheads %>%
+    mclapply(function(ahead) {
+      smoothed_scaled(
+        hhs_snapshot_edf,
+        outcome = "hhs_confirmed_admissions_covid_1d",
+        trainer = epipredict::quantile_reg(),
+        ahead = ahead,
+        lags = list(
+          # smoothed
+          7L * (0:4),
+          # sd
+          0L
+        ),
+        pop_scaling = TRUE
+      )
+    }, mc.cores = 6L) %>%
+    bind_rows()
+})
+
+fcst %>%
+  filter(geo_value == "az") %>%
+  ggplot(aes(target_end_date, value, group = quantile)) %>%
+  `+`(geom_line()) %>%
+  `+`(geom_line(data = hhs_up_to_date, aes(x = time_value, y = hhs_confirmed_admissions_covid_1d, group = NULL))) %>%
+  `+`(labs(title = "smoothed_scaling"))
+
+# plotting a "relative to truth" comparison
+zeroed <- fcst %>%
+  filter(geo_value == "az") %>%
+  left_join(hhs_up_to_date, by = join_by(target_end_date == time_value, geo_value == geo_value)) %>%
+  mutate(value = value - hhs_confirmed_admissions_covid_1d)
+ggplot(zeroed, aes(target_end_date, value, group = quantile)) +
+  geom_line() +
+  labs(title = "smoothed_scaled")
+
+fcst %>%
+  filter(
+    geo_value == "az",
+    target_end_date %in% range(target_end_date),
+    quantile %in% range(quantile)
+  )
+
+
+
+
+####################################################
+# the same, but only using the more recent training data
+####################################################
+short_start_date <- as.Date("2021-01-01")
+hhs_snapshot_short <-
+  cce$signals$`hhs:confirmed_admissions_covid_1d`$call(
+    "state", target_geo_values,
+    epirange(short_start_date, 34560101),
+    as_of = as.character(forecast_as_of)
+  )
+
+hhs_snapshot_short_edf <- hhs_snapshot_short %>%
+  pivot_wider(
+    id_cols = c("geo_value", "time_value"),
+    names_from = c("source", "signal"),
+    values_from = "value"
+  ) %>%
+  as_epi_df(as_of = forecast_as_of)
+
+system.time({
+  fcst_short <-
+    aheads %>%
+    mclapply(function(ahead) {
+      smoothed_scaled(
+        hhs_snapshot_short_edf,
+        outcome = "hhs_confirmed_admissions_covid_1d",
+        trainer = epipredict::quantile_reg(),
+        ahead = ahead,
+        lags = list(
+          # smoothed
+          7L * (0:4),
+          # sd
+          0L
+        ),
+        pop_scaling = TRUE
+      )
+    }, mc.cores = 6L) %>%
+    bind_rows()
+})
+
+zeroed_short <- fcst_short %>%
+  filter(geo_value == "az") %>%
+  left_join(hhs_up_to_date, by = join_by(target_end_date == time_value, geo_value == geo_value)) %>%
+  mutate(value = value - hhs_confirmed_admissions_covid_1d)
+ggplot(zeroed_short, aes(target_end_date, value, group = quantile)) +
+  geom_line() +
+  labs(title = "smoothed_scaled short")

--- a/scripts/one_offs/step-through-smoothed-scaled.R
+++ b/scripts/one_offs/step-through-smoothed-scaled.R
@@ -1,3 +1,5 @@
+# this script runs exactly one smoothed_scaled forecaster at the timepoint `forecast_as_of`.
+# the goal was to have a simple point comparison with our legacy forecasters
 library(dplyr)
 library(tidyr)
 library(parallel)


### PR DESCRIPTION
- Added the top 15 scoring models with at least a year of days after 2021 [from the dashboard](https://delphi.cmu.edu/forecast-eval/). You can get the updated version by running `make download`. 
- I moved the external scores file into `covid_hosp_explore`, since it is particular to that project.
- I added both the script I used to add those, along with the `step-through-smoothed-scaled.R` Logan wrote to `scripts/one_offs` in case we want to reference them later
closes #95 