### PR TITLE
testing: ab testing branch for epiprocess r6 refactor

### DIFF
--- a/R/looping.R
+++ b/R/looping.R
@@ -108,7 +108,8 @@ slide_forecaster <- function(data,
   names(res) <- sub("^slide_value_", "", names(res))
 
   # append the truth data
-  true_value <- archive$as_of(archive$versions_end) %>%
+  true_value <- archive %>%
+    epiprocess::epix_as_of(archive$versions_end) %>%
     select(geo_value, time_value, !!outcome) %>%
     rename(true_value = !!outcome)
   res %<>%

--- a/R/manage_S3.R
+++ b/R/manage_S3.R
@@ -28,9 +28,11 @@ manage_S3_forecast_cache <- function(rel_cache_dir = NULL,
 
   project_prefix <- paste0(prefix, "/", tar_project, "/")
   s3b <- get_bucket(bucket_name, prefix = project_prefix)
-  print(paste0(direction, "ing:"))
-  print(paste("local:", cache_path))
-  print(paste("remote:", prefix))
+  cli::cli_inform(c(
+    "{direction}ing cache to S3 bucket '{bucket_name}'",
+    "i" = "Local cache path: {cache_path}",
+    "i" = "AWS prefix: {prefix}"
+  ))
   if (direction == "sync") {
     if (verbose) {
       s3sync(cache_path, s3b, prefix = project_prefix)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ make push
 
 ### Directory Layout
 
-- `Makefile`: the main entrypoint for all pipelines
+- `run.R` and `Makefile`: the main entrypoint for all pipelines
 - `R/`: R package code to be reused
 - `scripts/`: plotting, code, and misc.
 - `tests/`: package tests

--- a/renv.lock
+++ b/renv.lock
@@ -812,14 +812,15 @@
     },
     "epidatr": {
       "Package": "epidatr",
-      "Version": "1.1.4",
+      "Version": "1.1.5",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteUsername": "cmu-delphi",
       "RemoteRepo": "epidatr",
-      "RemoteRef": "dev",
-      "RemoteSha": "a53ad5671cc072518feaed605637d0bf27fde3e6",
+      "RemoteUsername": "cmu-delphi",
+      "RemotePkgRef": "cmu-delphi/epidatr",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "626c30bc07f4aae3c3e6a6c6b825a6cd5eee1ce7",
       "Requirements": [
         "MMWRweek",
         "R",
@@ -838,19 +839,20 @@
         "usethis",
         "xml2"
       ],
-      "Hash": "c495a916c7f3aba065e09fcaceca4b01"
+      "Hash": "5c76408a283a0b20c6fd455fcd1c44b6"
     },
     "epipredict": {
       "Package": "epipredict",
-      "Version": "0.0.10",
+      "Version": "0.0.13",
       "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteUsername": "cmu-delphi",
-      "RemoteRepo": "epipredict",
-      "RemoteRef": "HEAD",
-      "RemoteSha": "7a4ea55437f6415e86b34d0fb7079ba7e8d5e286",
-      "RemoteHost": "api.github.com",
       "Remotes": "cmu-delphi/epidatr, cmu-delphi/epiprocess, dajmcdon/smoothqr",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "epipredict",
+      "RemoteUsername": "cmu-delphi",
+      "RemotePkgRef": "cmu-delphi/epipredict",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "8a516e96bbd0d647291700c32da9d4c5182e9f13",
       "Requirements": [
         "R",
         "checkmate",
@@ -858,13 +860,11 @@
         "distributional",
         "dplyr",
         "epiprocess",
-        "fs",
         "generics",
+        "ggplot2",
         "glue",
         "hardhat",
-        "lifecycle",
         "magrittr",
-        "methods",
         "parsnip",
         "quantreg",
         "recipes",
@@ -874,26 +874,25 @@
         "tibble",
         "tidyr",
         "tidyselect",
-        "usethis",
+        "tsibble",
         "vctrs",
         "workflows"
       ],
-      "Hash": "d59cd87c1aef1bfb1afce0bbf9b7c9c5"
+      "Hash": "c8f4f260388bc61e562f599c00c73fa6"
     },
     "epiprocess": {
       "Package": "epiprocess",
-      "Version": "0.7.5",
+      "Version": "0.7.7",
       "Source": "GitHub",
       "RemoteType": "github",
+      "RemoteHost": "api.github.com",
       "RemoteUsername": "cmu-delphi",
       "RemoteRepo": "epiprocess",
-      "RemoteRef": "HEAD",
-      "RemoteSha": "f29654512c4784c5a622b76b0ad13c0b43004d48",
-      "RemoteHost": "api.github.com",
+      "RemoteRef": "ds/r6-clean",
+      "RemoteSha": "d5c89b7e6bcf27d76aeb58c13c1bf9a528f92a3b",
       "Remotes": "cmu-delphi/epidatr, reconverse/outbreaks, glmgen/genlasso",
       "Requirements": [
         "R",
-        "R6",
         "checkmate",
         "cli",
         "data.table",
@@ -916,7 +915,7 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "d408b669e3b55d445b76272049fdb07e"
+      "Hash": "a6d480168d4ada8865470ca9912187a5"
     },
     "evaluate": {
       "Package": "evaluate",
@@ -1154,7 +1153,7 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "3.5.0",
+      "Version": "3.5.1",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -1175,7 +1174,7 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "52ef83f93f74833007f193b2d4c159a2"
+      "Hash": "44c6a2f8202d5b7e878ea274b1092426"
     },
     "gh": {
       "Package": "gh",

--- a/scripts/one_offs/r6_refactor.R
+++ b/scripts/one_offs/r6_refactor.R
@@ -1,0 +1,57 @@
+# R6 refactor comparison script.
+#
+# This script is used to compare the old and new R6 refactor objects to ensure
+# that the refactor did not change the forecast output. This script assumes that
+# you:
+#
+# 1. Ran the covid_hosp_explore pipeline (or downloaded the objects using `make
+#    download`)
+# 2. Copied the cache objects to a new directory (e.g. `covid_hosp_explore
+#    copy`)
+# 3. Installed the new epiprocess branch
+#    `renv::install("cmu-delphi/epiprocess@ds/r6-clean")`
+# 4. Ran the covid_hosp_explore pipeline again (should take about 3.5 hours)
+#
+# Once that is done, you should be able to run the script below and find no
+# differences in the forecasts.
+
+library(dplyr)
+library(magrittr)
+library(purrr)
+library(qs)
+
+df <- targets::tar_manifest()
+
+# Both have already been produced, so we can just read them in. Let's do a loop to compare them.
+old_forecasts <- list.files("covid_hosp_explore copy/objects", full.names = TRUE) %>%
+  keep(~ basename(.) %in% df$name) %>%
+  sort()
+new_forecasts <- list.files("covid_hosp_explore/objects", full.names = TRUE) %>%
+  keep(~ basename(.) %in% df$name) %>%
+  sort()
+
+# Make sure the lists are the same length and the basenames match
+assertthat::assert_that(
+  c(
+    length(old_forecasts) == length(new_forecasts),
+    basename(old_forecasts) == basename(new_forecasts)
+  ) %>% all()
+)
+
+tib <- tibble::tibble(
+  old_forecasts = old_forecasts,
+  new_forecasts = new_forecasts,
+  compare = purrr::map2_chr(old_forecasts, new_forecasts, function(x, y) {
+    # If objects are not the same, `all.equal` returns a character vector that
+    # can have `length` > 1. In that case, we need to collapse the output
+    # into a length-1 string so that `purrr::map2_chr` accepts it.
+    all.equal(qs::qread(x), qs::qread(y)) %>% as.character() %>% paste(collapse = "; ")
+  })
+)
+tib %>%
+  filter(compare != "TRUE") %>%
+  slice(1:5) %>%
+  c()
+
+x <- qread("covid_hosp_explore copy/objects/joined_archive_data_2022")
+y <- qread("covid_hosp_explore/objects/joined_archive_data_2022")

--- a/scripts/run.R
+++ b/scripts/run.R
@@ -26,9 +26,6 @@
 #   # Save to disk
 #   saveRDS(scorecards, "exploration-scorecards-2023-10-04.RDS")
 
-
-
-
 tar_project <- Sys.getenv("TAR_PROJECT", "covid_hosp_explore")
 external_scores_path <- Sys.getenv("EXTERNAL_SCORES_PATH", "")
 debug_mode <- as.logical(Sys.getenv("DEBUG_MODE", TRUE))
@@ -64,7 +61,7 @@ tar_manifest()
 if (debug_mode) {
   tar_make(callr_function = NULL, use_crew = FALSE)
 } else {
-  tar_make(use_crew = TRUE)
+  tar_make()
 }
 
 if (use_shiny) {


### PR DESCRIPTION
Companion branch for https://github.com/cmu-delphi/epiprocess/pull/431. 

Reduces the `covid_hosp_explore` project to a subset of the forecasters for faster comparison. I found no differences in the forecast outputs. See the `r6_refactor.R` script for instructions for how to replicate.