### PR TITLE
enh: forecaster cleanup

### DIFF
--- a/R/new_epipredict_steps/step_training_window.R
+++ b/R/new_epipredict_steps/step_training_window.R
@@ -15,7 +15,7 @@
 #'   Expects n_recent to be finite.
 #' @param seasonal_forward_window An integer value that represents the number of days
 #'   after a season week to include in the training window. The default value
-#'   is 14. Only valid when seasonal is TRUE.
+#'   is 21. Only valid when seasonal is TRUE.
 #' @param seasonal_backward_window An integer value that represents the number of days
 #'   before a season week to include in the training window. The default value
 #'   is 35. Only valid when seasonal is TRUE.
@@ -50,14 +50,16 @@
 #'   prep(tib) %>%
 #'   bake(new_data = NULL)
 step_epi_training_window <-
-  function(recipe,
-           role = NA,
-           n_recent = 50,
-           seasonal = FALSE,
-           seasonal_forward_window = 14,
-           seasonal_backward_window = 35,
-           epi_keys = NULL,
-           id = rand_id("epi_training_window")) {
+  function(
+    recipe,
+    role = NA,
+    n_recent = 50,
+    seasonal = FALSE,
+    seasonal_forward_window = 21,
+    seasonal_backward_window = 35,
+    epi_keys = NULL,
+    id = rand_id("epi_training_window")
+  ) {
     epipredict:::arg_is_scalar(n_recent, id, seasonal, seasonal_forward_window, seasonal_backward_window)
     epipredict:::arg_is_pos(n_recent, seasonal_forward_window, seasonal_backward_window)
     if (is.finite(n_recent)) epipredict:::arg_is_pos_int(n_recent)
@@ -150,7 +152,6 @@ bake.step_epi_training_window <- function(object, new_data, ...) {
     new_data %<>% filter(time_value %in% date_ranges)
   }
 
-
   new_data
 }
 
@@ -162,8 +163,17 @@ print.step_epi_training_window <-
       n_recent <- x$n_recent
       seasonal_forward_window <- x$seasonal_forward_window
       seasonal_backward_window <- x$seasonal_backward_window
-      tr_obj <- recipes::format_selectors(rlang::enquos(n_recent, seasonal_forward_window, seasonal_backward_window), width)
-      recipes::print_step(tr_obj, rlang::enquos(n_recent, seasonal_forward_window, seasonal_backward_window), x$trained, title, width)
+      tr_obj <- recipes::format_selectors(
+        rlang::enquos(n_recent, seasonal_forward_window, seasonal_backward_window),
+        width
+      )
+      recipes::print_step(
+        tr_obj,
+        rlang::enquos(n_recent, seasonal_forward_window, seasonal_backward_window),
+        x$trained,
+        title,
+        width
+      )
     } else {
       title <- "# of recent observations per key limited to:"
       n_recent <- x$n_recent

--- a/R/targets/covid_forecaster_config.R
+++ b/R/targets/covid_forecaster_config.R
@@ -14,7 +14,7 @@ get_covid_forecaster_params <- function() {
   out <- rlang::list2(
     scaled_pop_main = tidyr::expand_grid(
       forecaster = "scaled_pop",
-      trainer = list("linreg", "quantreg"),
+      trainer = "quantreg",
       lags = list(
         c(0, 7),
         c(0, 7, 14),

--- a/R/targets/covid_forecaster_config.R
+++ b/R/targets/covid_forecaster_config.R
@@ -167,9 +167,6 @@ get_covid_forecaster_params <- function() {
       if ("trainer" %in% names(x) && is.list(x$trainer)) {
         x$trainer <- x$trainer[[1]]
       }
-      if ("seasonal_method" %in% names(x) && is.list(x$seasonal_method)) {
-        x$seasonal_method <- x$seasonal_method[[1]]
-      }
       # Add the outcome to each forecaster.
       x$outcome <- "hhs"
       x

--- a/R/targets/flu_forecaster_config.R
+++ b/R/targets/flu_forecaster_config.R
@@ -215,7 +215,7 @@ get_flu_forecaster_params <- function() {
         seasonal_method = list("flu", "indicator", "climatological"),
         pop_scaling = FALSE,
         train_residual = c(TRUE, FALSE),
-        filter_source = "",
+        filter_source = c("", "nhsn"),
         filter_agg_level = "state",
         drop_non_seasons = c(TRUE, FALSE),
         n_training = Inf,
@@ -231,7 +231,7 @@ get_flu_forecaster_params <- function() {
         seasonal_method = list("window", c("window", "flu"), c("window", "climatological")),
         pop_scaling = FALSE,
         train_residual = c(FALSE, TRUE),
-        filter_source = "",
+        filter_source = c("", "nhsn"),
         filter_agg_level = "state",
         drop_non_seasons = FALSE,
         n_training = Inf,
@@ -252,7 +252,7 @@ get_flu_forecaster_params <- function() {
         ),
         seasonal_method = "window",
         pop_scaling = FALSE,
-        filter_source = "",
+        filter_source = c("", "nhsn"),
         filter_agg_level = "state",
         n_training = Inf,
         drop_non_seasons = FALSE,
@@ -265,7 +265,7 @@ get_flu_forecaster_params <- function() {
       lags = list(
         c(0, 7)
       ),
-      seasonal_method = list("window"),
+      seasonal_method = "window",
       pop_scaling = FALSE,
       train_residual = FALSE,
       filter_source = c("", "nhsn"),
@@ -327,9 +327,6 @@ get_flu_forecaster_params <- function() {
       x <- add_id(x)
       if ("trainer" %in% names(x) && is.list(x$trainer)) {
         x$trainer <- x$trainer[[1]]
-      }
-      if ("seasonal_method" %in% names(x) && is.list(x$seasonal_method)) {
-        x$seasonal_method <- x$seasonal_method[[1]]
       }
       # Add the outcome to each forecaster.
       x$outcome <- "hhs"

--- a/R/targets/flu_forecaster_config.R
+++ b/R/targets/flu_forecaster_config.R
@@ -10,50 +10,29 @@
 #' @export
 get_flu_forecaster_params <- function() {
   out <- rlang::list2(
-    # just the data, possibly population scaled; likely to run into troubles
-    # because of the scales of the different sources
-    scaled_pop_main = bind_rows(
-      tidyr::expand_grid(
-        forecaster = "scaled_pop",
-        trainer = "quantreg",
-        lags = list2(
-          c(0, 7),
-          c(0, 7, 14, 21),
-        ),
-        pop_scaling = FALSE,
-        filter_source = "nhsn",
-        filter_agg_level = "state",
-        scale_method = "none",
-        center_method = "median",
-        nonlin_method = c("quart_root", "none"),
-        n_training = Inf,
-        drop_non_seasons = TRUE,
-        keys_to_ignore = g_very_latent_locations
+    scaled_pop_main = tidyr::expand_grid(
+      forecaster = "scaled_pop",
+      trainer = "quantreg",
+      lags = list2(
+        c(0, 7),
+        c(0, 7, 14, 21),
       ),
-      tidyr::expand_grid(
-        forecaster = "scaled_pop",
-        trainer = "quantreg",
-        lags = list2(
-          c(0, 7),
-          c(0, 7, 14, 21),
-        ),
-        pop_scaling = FALSE,
-        filter_source = "nhsn",
-        filter_agg_level = "state",
-        scale_method = "quantile",
-        center_method = "median",
-        nonlin_method = "quart_root",
-        n_training = Inf,
-        drop_non_seasons = TRUE,
-        keys_to_ignore = g_very_latent_locations
-      )
+      pop_scaling = FALSE,
+      filter_source = "nhsn",
+      filter_agg_level = "state",
+      scale_method = "quantile",
+      center_method = "median",
+      nonlin_method = "quart_root",
+      n_training = Inf,
+      drop_non_seasons = TRUE,
+      keys_to_ignore = g_very_latent_locations
     ),
     scaled_pop_data_augmented = tidyr::expand_grid(
       forecaster = "scaled_pop",
       trainer = "quantreg",
-      lags = list(
+      lags = list2(
+        c(0, 7),
         c(0, 7, 14, 21),
-        c(0, 7)
       ),
       pop_scaling = FALSE,
       scale_method = "quantile",
@@ -65,9 +44,6 @@ get_flu_forecaster_params <- function() {
       drop_non_seasons = TRUE,
       keys_to_ignore = g_very_latent_locations
     ),
-    ## # The covid forecaster, ported over to flu. Also likely to struggle with the
-    ## # extra data
-    # the thing to beat (a simplistic baseline forecast)
     flatline = tidyr::expand_grid(
       forecaster = "flatline_fc",
       filter_source = "nhsn",
@@ -82,7 +58,7 @@ get_flu_forecaster_params <- function() {
         extra_sources = list2("nssp", "google_symptoms", "nwss", "nwss_region", "va_flu_per_100k"),
         lags = list2(
           list2(
-            c(0, 7, 14, 21), # hhs
+            c(0, 7), # hhs
             c(0, 7) # exogenous feature
           )
         ),
@@ -112,7 +88,7 @@ get_flu_forecaster_params <- function() {
         ),
         lags = list2(
           list2(
-            c(0, 7, 14, 21), # hhs
+            c(0, 7), # hhs
             c(0, 7), # first feature
             c(0, 7) # second feature
           )
@@ -135,7 +111,7 @@ get_flu_forecaster_params <- function() {
         ),
         lags = list2(
           list2(
-            c(0, 7, 14, 21), # hhs
+            c(0, 7), # hhs
             c(0, 7), # nssp
             c(0, 7), # google symptoms
             c(0, 7), # nwss
@@ -154,108 +130,95 @@ get_flu_forecaster_params <- function() {
         keys_to_ignore = g_very_latent_locations,
       )
     ),
-    ## # another kind of baseline forecaster
-    ## no_recent_quant = tidyr::expand_grid(
-    ##   forecaster = "no_recent_outcome",
-    ##   trainer = "quantreg",
-    ##   scale_method = "quantile",
-    ##   nonlin_method = "quart_root",
-    ##   filter_source = "",
-    ##   use_population = c(TRUE, FALSE),
-    ##   use_density = c(TRUE, FALSE),
-    ##   week_method = "sine",
-    ##   keys_to_ignore = g_very_latent_locations
-    ## ),
-    no_recent_but_exogenous = bind_rows(
-      expand_grid(
-        forecaster = "no_recent_outcome",
-        trainer = "quantreg",
-        # since it's a list, this gets expanded out to a single one in each row
-        extra_sources = list2("nssp", "google_symptoms", "nwss", "nwss_region", "va_flu_per_100k"),
-        lags = list2(
-          list2(
-            # no hhs
-            c(0, 7) # exogenous feature
-          )
-        ),
-        scale_method = "quantile",
-        nonlin_method = "quart_root",
-        filter_source = c("", "nhsn"),
-        use_population = TRUE,
-        use_density = FALSE,
-        week_method = "sine",
-        n_training = Inf,
-        keys_to_ignore = g_very_latent_locations
-      ),
-      # expand_grid(
-      #   forecaster = "no_recent_outcome",
-      #   trainer = "quantreg",
-      #   extra_sources = list2(
-      #     c("nssp", "google_symptoms"),
-      #     c("nssp", "nwss"),
-      #     c("nssp", "nwss_region"),
-      #     c("google_symptoms", "nwss"),
-      #     c("google_symptoms", "nwss_region"),
-      #     c("nwss", "nwss_region")
-      #   ),
-      #   lags = list2(
-      #     list2(
-      #       # no hhs
-      #       c(0, 7), # first feature
-      #       c(0, 7) # second feature
-      #     )
-      #   ),
-      #   scale_method = "quantile",
-      #   nonlin_method = "quart_root",
-      #   filter_source = c("", "nhsn"),
-      #   use_population = TRUE,
-      #   use_density = FALSE,
-      #   week_method = "sine",
-      #   n_training = Inf,
-      #   keys_to_ignore = g_very_latent_locations
-      # ),
-      expand_grid(
-        forecaster = "no_recent_outcome",
-        trainer = "quantreg",
-        extra_sources = list2(
-          c("nssp", "google_symptoms", "nwss", "nwss_region", "va_flu_per_100k"),
-        ),
-        lags = list2(
-          list2(
-            # no hhs
-            c(0, 7), # nssp
-            c(0, 7), # google symptoms
-            c(0, 7), # nwss
-            c(0, 7), # nwss_region
-            c(0, 7), # va_flu_per_100k
-          )
-        ),
-        scale_method = "quantile",
-        nonlin_method = "quart_root",
-        filter_source = c("", "nhsn"),
-        use_population = TRUE,
-        use_density = FALSE,
-        week_method = "sine",
-        n_training = Inf,
-        keys_to_ignore = g_very_latent_locations
-      )
-    ),
+    # This is broken (scale issue?)
+    # no_recent_but_exogenous = bind_rows(
+    #   expand_grid(
+    #     forecaster = "no_recent_outcome",
+    #     trainer = "quantreg",
+    #     # since it's a list, this gets expanded out to a single one in each row
+    #     extra_sources = list2("nssp", "google_symptoms", "nwss", "nwss_region", "va_flu_per_100k"),
+    #     lags = list2(
+    #       list2(
+    #         # no hhs
+    #         c(0, 7) # exogenous feature
+    #       )
+    #     ),
+    #     scale_method = "quantile",
+    #     nonlin_method = "quart_root",
+    #     filter_source = "",
+    #     use_population = TRUE,
+    #     use_density = FALSE,
+    #     week_method = "sine",
+    #     n_training = Inf,
+    #     keys_to_ignore = g_very_latent_locations
+    #   ),
+    #   expand_grid(
+    #     forecaster = "no_recent_outcome",
+    #     trainer = "quantreg",
+    #     extra_sources = list2(
+    #       c("nssp", "google_symptoms"),
+    #       c("nssp", "nwss"),
+    #       c("nssp", "nwss_region"),
+    #       c("google_symptoms", "nwss"),
+    #       c("google_symptoms", "nwss_region"),
+    #       c("nwss", "nwss_region")
+    #     ),
+    #     lags = list2(
+    #       list2(
+    #         # no hhs
+    #         c(0, 7), # first feature
+    #         c(0, 7) # second feature
+    #       )
+    #     ),
+    #     scale_method = "quantile",
+    #     nonlin_method = "quart_root",
+    #     filter_source = "",
+    #     use_population = TRUE,
+    #     use_density = FALSE,
+    #     week_method = "sine",
+    #     n_training = Inf,
+    #     keys_to_ignore = g_very_latent_locations
+    #   ),
+    #   expand_grid(
+    #     forecaster = "no_recent_outcome",
+    #     trainer = "quantreg",
+    #     extra_sources = list2(
+    #       c("nssp", "google_symptoms", "nwss", "nwss_region", "va_flu_per_100k"),
+    #     ),
+    #     lags = list2(
+    #       list2(
+    #         # no hhs
+    #         c(0, 7), # nssp
+    #         c(0, 7), # google symptoms
+    #         c(0, 7), # nwss
+    #         c(0, 7), # nwss_region
+    #         c(0, 7), # va_flu_per_100k
+    #       )
+    #     ),
+    #     scale_method = "quantile",
+    #     nonlin_method = "quart_root",
+    #     filter_source = "",
+    #     use_population = TRUE,
+    #     use_density = FALSE,
+    #     week_method = "sine",
+    #     n_training = Inf,
+    #     keys_to_ignore = g_very_latent_locations
+    #   )
+    # ),
     scaled_pop_season = bind_rows(
       tidyr::expand_grid(
         forecaster = "scaled_pop_seasonal",
         trainer = "quantreg",
-        lags = list(
-          c(0, 7, 14, 21),
+        lags = list2(
           c(0, 7)
         ),
         seasonal_method = list("flu", "indicator", "climatological"),
         pop_scaling = FALSE,
         train_residual = c(TRUE, FALSE),
-        filter_source = "nhsn",
+        filter_source = "",
         filter_agg_level = "state",
         drop_non_seasons = c(TRUE, FALSE),
         n_training = Inf,
-        seasonal_backward_window = 5,
         keys_to_ignore = g_very_latent_locations
       ),
       # Window-based seasonal method shouldn't drop non-seasons
@@ -268,27 +231,10 @@ get_flu_forecaster_params <- function() {
         seasonal_method = list("window", c("window", "flu"), c("window", "climatological")),
         pop_scaling = FALSE,
         train_residual = c(FALSE, TRUE),
-        filter_source = c("", "nhsn"),
+        filter_source = "",
         filter_agg_level = "state",
         drop_non_seasons = FALSE,
         n_training = Inf,
-        seasonal_backward_window = 5,
-        keys_to_ignore = g_very_latent_locations
-      ),
-      tidyr::expand_grid(
-        forecaster = "scaled_pop_seasonal",
-        trainer = "quantreg",
-        lags = list(
-          c(0, 7, 14, 21)
-        ),
-        seasonal_method = list("window", c("window", "flu"), c("window", "climatological")),
-        pop_scaling = FALSE,
-        train_residual = c(FALSE, TRUE),
-        filter_source = c("", "nhsn"),
-        filter_agg_level = "state",
-        drop_non_seasons = FALSE,
-        n_training = Inf,
-        seasonal_backward_window = 8,
         keys_to_ignore = g_very_latent_locations
       )
     ),
@@ -322,12 +268,12 @@ get_flu_forecaster_params <- function() {
       seasonal_method = list("window"),
       pop_scaling = FALSE,
       train_residual = FALSE,
-      filter_source = "",
+      filter_source = c("", "nhsn"),
       filter_agg_level = "state",
       drop_non_seasons = FALSE,
       n_training = Inf,
-      seasonal_backward_window = c(3, 5, 7, 9, 52),
-      seasonal_forward_window = c(3, 5, 7),
+      seasonal_backward_window = c(3 * 7, 5 * 7, 7 * 7),
+      seasonal_forward_window = c(7, 3 * 7, 5 * 7),
       keys_to_ignore = g_very_latent_locations
     ),
     climate_linear = bind_rows(

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Some general tips:
 
 - Do not rely on a forecasting pipeline to get the data you need. Forecasting
   pipelines are bulky and are not designed for fast polling, which is the
-  opposite of what you want from an up-to-date data script. Instead, write a
+  opposite of what you want from a fast fetching script. Instead, write a
   script that polls your source frequently, gets the raw data, and builds an
   archive. See `scripts/build_nhsn_archive.R` for an example of how to do this.
   Then, you can make your forecasting pipeline depend on this archive, which
@@ -159,10 +159,10 @@ you into the R debugger.
 
 ### Adding a new forecaster
 
-To add a new forecaster, we recommend the following process.
-
-First, add a new forecaster function in `R/forecasters/` with the following
-general format:
+To add a new forecaster, we recommend copying the `scaled_pop` forecaster and
+modifying it to suit your needs. What follows is a brief introduction to the
+structure of a typical forecaster function. First, add a new forecaster function
+in `R/forecasters/` with the following general format:
 
 ```r
 function(epi_data,

--- a/reports/template.md
+++ b/reports/template.md
@@ -15,13 +15,16 @@
 
 ### Flu
 
+All forecasters population scale their data, use geo pooling, and train using quantreg.
+These definitions are in the `flu_forecaster_config.R` file.
+
 - [Flu Overall](flu-overall-notebook.html)
-- [Flu AR with population scaling (quantile reg)](flu-notebook-scaled_pop_main.html)
-- [Flu AR with population scaling and data augmented](flu-notebook-scaled_pop_data_augmented.html)
-- [Flu AR with population scaling, data augmented, and exogenous features](flu-notebook-scaled_pop_exogenous.html)
-- [Flu AR with seasonal features](flu-notebook-scaled_pop_season.html)
-- [Flu AR seasonal window size comparisons](flu-notebook-season_window_sizes.html)
-- [Flu AR with seasonal features and exogenous features](flu-notebook-scaled_pop_season_exogenous.html)
+- [Flu AR](flu-notebook-scaled_pop_main.html)
+- [Flu AR with augmented data](flu-notebook-scaled_pop_data_augmented.html)
+- [Flu AR with exogenous features](flu-notebook-scaled_pop_exogenous.html)
+- [Flu AR with different seasonal schemes](flu-notebook-scaled_pop_season.html)
+- [Flu AR with augmented data and with different seasonal window sizes](flu-notebook-season_window_sizes.html)
+- [Flu AR with augmented data, exogenous features, and seasonal windowing](flu-notebook-scaled_pop_season_exogenous.html)
 
 Simplistic/low data methods:
 
@@ -29,11 +32,14 @@ Simplistic/low data methods:
 - [Flu flatline](flu-notebook-flatline.html)
 - [Flu climate](flu-notebook-climate_linear.html)
 
-### Covid (new)
+### Covid
 
-- [Covid AR with population scaling](covid-notebook-scaled_pop_main.html)
-- [Covid AR with population scaling and seasonal features](covid-notebook-scaled_pop_season.html)
-- [Covid AR with population scaling, and exogenous features](covid-notebook-scaled_pop_exogenous.html)
+All forecasters population scale their data, use geo pooling, and train using quantreg.
+These definitions are in the `covid_forecaster_config.R` file.
+
+- [Covid AR](covid-notebook-scaled_pop_main.html)
+- [Covid AR with seasonal features](covid-notebook-scaled_pop_season.html)
+- [Covid AR with exogenous features](covid-notebook-scaled_pop_exogenous.html)
 - [Covid Flatline](covid-notebook-flatline_forecaster.html)
 
 Simplistic/low data methods:
@@ -41,12 +47,6 @@ Simplistic/low data methods:
 - [Covid no recent](covid-notebook-no_recent_quant.html)
 - [Covid flatline](covid-notebook-flatline.html)
 - [Covid climate](covid-notebook-climate_linear.html)
-
-### Covid (old)
-
-- [Covid AR with population scaling](covid-notebook-1.html)
-- [Covid AR with population scaling and smoothed features](covid-notebook-2.html)
-- [Covid Flatline](covid-notebook-3.html)
 
 ## Descriptions of Forecaster Families
 

--- a/scripts/reports/comparison-notebook.Rmd
+++ b/scripts/reports/comparison-notebook.Rmd
@@ -41,10 +41,10 @@ library(purrr)
 
 ```{r}
 # outside_forecaster_subset <- c("COVIDhub-baseline", "COVIDhub-trained_ensemble", "COVIDhub_CDC-ensemble")
-# i <- 1
-# forecaster_families <- tar_read(forecaster_params_grid)$family %>% unique()
+# i <- 5
+# forecaster_families <- names(tar_read(forecaster_parameter_combinations))
 # forecaster_family <- forecaster_families[[i]]
-# params_subset <- tar_read(forecaster_params_grid) %>% filter(family == forecaster_family)
+# params_subset <- tar_read(forecaster_parameter_combinations)[[forecaster_family]]
 # forecasts_subset <- tar_read(joined_forecasts) %>% filter(forecaster %in% c(params_subset$id, outside_forecaster_subset))
 # scores_subset <- tar_read(joined_scores) %>% filter(forecaster %in% c(params_subset$id, outside_forecaster_subset))
 
@@ -109,7 +109,8 @@ param_table <- params$forecaster_parameters %>%
   select(-any_of(ignore_keys)) %>%
   mutate(
     across(matches("^n_training$"), ~ as.character(.x)),
-    across(matches("^trainer$"), ~ unlist(.x))
+    across(matches("^trainer$"), ~ unlist(.x)),
+    across(matches("^seasonal_method$"), ~ Vectorize(function(x) paste0(x, collapse = ", "))(.x))
   ) %>%
   full_join(
     scores %>%


### PR DESCRIPTION
A few things:
- lags 0, 7 for hhs were consistently the best scoring individually, so I replaced 0, 7, 14, 21 in the exogenous case as well 
- no recent outcome is [borked](https://delphi-forecasting-reports.netlify.app/flu-notebook-no_recent_quant), so don't bother with it
- make step_epi_training_window default match default_arx_args_list
- speaking of training windows, use a much larger range of values for the window, rather than a few small ones and one giant one (same for both backward and forward)
- also try augmented versus no augmented everywhere - the results are surprisingly mixed (the best among seasonal methods were the ones without augmented data, which was surprising to me)
- remove a stray very short seasonal_backward_window = 5 argument in seasonal feature tests
- seasonal_method was always coming up as "flu" in the params table, either it was always being used that way internally or it was just a table thing; tried to fix both